### PR TITLE
Gpu likelihood

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/src/linalg/chol.jl
+++ b/src/linalg/chol.jl
@@ -1,5 +1,27 @@
-
 using CUDA
+
+function zero_upper!(A::CuArray)
+    B, N, _ = size(A)
+    total = B * N * N
+    threads = 256
+    blocks = cld(total, threads)
+    @cuda threads=threads blocks=blocks zero_upper_kernel!(A, B, N)
+end
+
+@cuda function zero_upper_kernel!(A, B, N)
+    idx = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    total = B * N * N
+    if idx <= total
+        b = 1 + (idx - 1) % B
+        ij = (idx - 1) ÷ B
+        j = 1 + (ij ÷ N)
+        i = 1 + (ij % N)
+        if i < j
+            A[b, i, j] = 0
+        end
+    end
+    return A
+end
 
 function ldl_striped_matrix!(A::Array, ϵ = eps(real(eltype(A))))
     @assert size(A,2) == size(A,3)
@@ -33,7 +55,7 @@ function ldl_striped_matrix!(A::Array, ϵ = eps(real(eltype(A))))
     D, A
 end
 
-function ldl_striped_matrix_gpu!(A::CuArray{T,3}, ϵ = eps(real(T))) where T<:Union{ComplexF32, ComplexF64}
+function ldl_striped_matrix!(A::CuArray{T,3}, ϵ = eps(real(T))) where T<:Union{ComplexF32, ComplexF64}
     
     @assert size(A,2) == size(A,3)
     B = size(A,1)
@@ -41,12 +63,22 @@ function ldl_striped_matrix_gpu!(A::CuArray{T,3}, ϵ = eps(real(T))) where T<:Un
     D = CUDA.zeros(eltype(A), B, N)
     buf = CUDA.zeros(eltype(A), B)
 
-    @inbounds for j in 1:N
-        Lj = view(A,1:B,j,1:j-1)
-        Dj = view(D,1:B,1:j-1)
-        @tullio buf[b] = abs2(Lj[b,k]) * Dj[b,k]
-        @. D[:,j] = A[:,j,j] - buf
-
+    @allowscalar for j in 1:N
+        if j > 1
+            Lj = view(A, :, j, 1:j-1)
+            Dj = view(D, :, 1:j-1)
+            for b in 1:B
+                acc = zero(eltype(A))
+                for k in 1:j-1
+                    acc += abs2(Lj[b,k])*Dj[b,k]
+                end
+                buf[b] = acc
+            end
+        else
+            buf .= 0
+        end
+       
+        D[:, j] .= A[:,j,j].-buf
         A[:,j,j] .= one(eltype(A))
 
         if any(abs.(D[:,j]) .≤ ϵ)
@@ -54,47 +86,23 @@ function ldl_striped_matrix_gpu!(A::CuArray{T,3}, ϵ = eps(real(T))) where T<:Un
         end
 
         for i in j+1:N
-            Li = view(A,1:B,i,1:j-1)
-            @tullio buf[b] = Li[b,k] * conj(Lj[b,k]) * Dj[b,k]
-            @. A[:,i,j] = (A[:,i,j] - buf) / D[:,j]
+            Li = view(A,:, i,1:j-1)
+            for b in 1:B
+                acc = zero(eltype(A))
+                for k in 1:j-1
+                    acc += Li[b,k] * conj(Lk[b,k])*Dj[b,k]
+                end
+            A[b,i,j]=(A[b,i,j] - acc)/D[b,j]
+            end
         end
     end
 
-    @inbounds for j in 1:N, i in 1:j-1
-        A[:,i,j] .= zero(eltype(A))
-    end
-
+   
+    zero_upper!(A)
     return D, A
 end
 
 function cholesky_striped_matrix!(A::Array, ϵ = eps(real(eltype(A))))
-    @assert size(A,2) == size(A,3)
-    B = size(A,1)
-    N = size(A,2)
-    buf =CUDA.zeros(eltype(A), B)
-
-    for j in 1:N
-        Lj = view(A,1:B,j,1:j-1)
-        @tullio buf[b] = abs2(Lj[b,k])
-        A[:,j,j] = sqrt.(A[:,j,j] - buf)
-
-        if any(@. abs(A[:,j,j]) ≤ ϵ)
-            nothing
-        end
-        
-        @inbounds for i in j+1:N
-            Li = view(A,1:B,i,1:j-1)
-            @tullio buf[b] = conj(Lj[k])*Li[k]
-            A[:,i,j] = (A[:,i,j] - buf)./A[:,j,j]
-        end
-    end
-    @inbounds for j in 1:N, i in 1:j-1
-        A[:,i,j] .= zero(eltype(A))
-    end
-    A
-end
-
-function cholesky_striped_matrix_gpu!(A::CuArray{T,3}, ϵ = eps(real(T))) where T<:Union{ComplexF32, ComplexF64}
     @assert size(A,2) == size(A,3)
     B = size(A,1)
     N = size(A,2)
@@ -119,4 +127,46 @@ function cholesky_striped_matrix_gpu!(A::CuArray{T,3}, ϵ = eps(real(T))) where 
         A[:,i,j] .= zero(eltype(A))
     end
     A
+end
+
+function cholesky_striped_matrix!(A::CuArray{T,3}, ϵ = eps(real(T))) where T<:Union{ComplexF32, ComplexF64}
+    @assert size(A,2) == size(A,3)
+    B, N = size(A,1), size(A,2)
+    buf = CUDA.zeros(T, B)
+
+    @allowscalar for j in 1:N
+        if j > 1
+            Lj = view(A, :, j, 1:j-1)
+            for b in 1:B
+                acc = zero(T)
+                for k in 1:j-1
+                    acc += abs2(Lj[b,k])
+                end
+                buf[b] = acc
+            end
+        else
+            buf .= 0
+        end
+
+        A[:,j,j] .= sqrt.(A[:,j,j] .- buf)
+
+        if any(abs.(A[:,j,j]) .≤ ϵ)
+            return nothing
+        end
+
+        for i in j+1:N
+            Lj = view(A,:,j,1:j-1)
+            Li = view(A,:,i,1:j-1)
+            for b in 1:B
+                acc = zero(T)
+                for k in 1:j-1
+                    acc += conj(Lj[b,k]) * Li[b,k]
+                end
+                A[b,i,j] = (A[b,i,j] - acc) / A[b,j,j]
+            end
+        end
+    end
+
+    zero_upper!(A)
+    return A
 end

--- a/src/linalg/chol.jl
+++ b/src/linalg/chol.jl
@@ -1,4 +1,6 @@
 
+using CUDA
+
 function ldl_striped_matrix!(A::Array, ϵ = eps(real(eltype(A))))
     @assert size(A,2) == size(A,3)
     B = size(A,1)
@@ -31,7 +33,68 @@ function ldl_striped_matrix!(A::Array, ϵ = eps(real(eltype(A))))
     D, A
 end
 
+function ldl_striped_matrix_gpu!(A::CuArray{T,3}, ϵ = eps(real(T))) where T<:Union{ComplexF32, ComplexF64}
+    
+    @assert size(A,2) == size(A,3)
+    B = size(A,1)
+    N = size(A,2)
+    D = CUDA.zeros(eltype(A), B, N)
+    buf = CUDA.zeros(eltype(A), B)
+
+    @inbounds for j in 1:N
+        Lj = view(A,1:B,j,1:j-1)
+        Dj = view(D,1:B,1:j-1)
+        @tullio buf[b] = abs2(Lj[b,k]) * Dj[b,k]
+        @. D[:,j] = A[:,j,j] - buf
+
+        A[:,j,j] .= one(eltype(A))
+
+        if any(abs.(D[:,j]) .≤ ϵ)
+            return nothing, nothing  # fail-fast on singular block
+        end
+
+        for i in j+1:N
+            Li = view(A,1:B,i,1:j-1)
+            @tullio buf[b] = Li[b,k] * conj(Lj[b,k]) * Dj[b,k]
+            @. A[:,i,j] = (A[:,i,j] - buf) / D[:,j]
+        end
+    end
+
+    @inbounds for j in 1:N, i in 1:j-1
+        A[:,i,j] .= zero(eltype(A))
+    end
+
+    return D, A
+end
+
 function cholesky_striped_matrix!(A::Array, ϵ = eps(real(eltype(A))))
+    @assert size(A,2) == size(A,3)
+    B = size(A,1)
+    N = size(A,2)
+    buf =CUDA.zeros(eltype(A), B)
+
+    for j in 1:N
+        Lj = view(A,1:B,j,1:j-1)
+        @tullio buf[b] = abs2(Lj[b,k])
+        A[:,j,j] = sqrt.(A[:,j,j] - buf)
+
+        if any(@. abs(A[:,j,j]) ≤ ϵ)
+            nothing
+        end
+        
+        @inbounds for i in j+1:N
+            Li = view(A,1:B,i,1:j-1)
+            @tullio buf[b] = conj(Lj[k])*Li[k]
+            A[:,i,j] = (A[:,i,j] - buf)./A[:,j,j]
+        end
+    end
+    @inbounds for j in 1:N, i in 1:j-1
+        A[:,i,j] .= zero(eltype(A))
+    end
+    A
+end
+
+function cholesky_striped_matrix_gpu!(A::CuArray{T,3}, ϵ = eps(real(T))) where T<:Union{ComplexF32, ComplexF64}
     @assert size(A,2) == size(A,3)
     B = size(A,1)
     N = size(A,2)

--- a/src/linalg/striped.jl
+++ b/src/linalg/striped.jl
@@ -48,7 +48,7 @@ end
 @inline function safe_complex_reciprocal(x, ϵ)
     a     = real(x)
     b     = imag(x)
-    x_mag = a*a + b*b 
+    x_mag = a*a + b*b + ϵ
     Complex(a/x_mag, -b/x_mag)
 end
 

--- a/src/linalg/trsv.jl
+++ b/src/linalg/trsv.jl
@@ -14,3 +14,19 @@ function trsv_striped_matrix!(A::AbstractArray, x::Array)
     end
     x
 end
+
+function trsv_striped_matrix_gpu!(A::CudaArray{T,3}, x::Array)
+    @assert size(A,2) == size(A,3)
+    @assert size(A,2) == size(x,2)
+    @assert size(A,1) == size(x,1)
+    B   = size(A,1)
+    N   = size(A,2)
+    buf = CUDA.zeros(eltype(A), B)
+    @inbounds for i in 1:N
+        Ai = view(A, 1:B, i, 1:i-1)
+        xi = view(x, 1:B,    1:i-1)
+        @tullio buf[b] = Ai[b,k].*xi[b,k] 
+        x[:,i] = (x[:,i] - buf)./A[:,i,i]
+    end
+    x
+end

--- a/src/linalg/trsv.jl
+++ b/src/linalg/trsv.jl
@@ -1,3 +1,4 @@
+using CUDA
 
 function trsv_striped_matrix!(A::AbstractArray, x::Array)
     @assert size(A,2) == size(A,3)
@@ -15,7 +16,7 @@ function trsv_striped_matrix!(A::AbstractArray, x::Array)
     x
 end
 
-function trsv_striped_matrix_gpu!(A::CudaArray{T,3}, x::Array)
+function trsv_striped_matrix!(A::CuArray{T,3}, x::CuArray)
     @assert size(A,2) == size(A,3)
     @assert size(A,2) == size(x,2)
     @assert size(A,1) == size(x,1)
@@ -25,8 +26,8 @@ function trsv_striped_matrix_gpu!(A::CudaArray{T,3}, x::Array)
     @inbounds for i in 1:N
         Ai = view(A, 1:B, i, 1:i-1)
         xi = view(x, 1:B,    1:i-1)
-        @tullio buf[b] = Ai[b,k].*xi[b,k] 
+        @tullio threads=false buf[b] = Ai[b,k].*xi[b,k] 
         x[:,i] = (x[:,i] - buf)./A[:,i,i]
     end
-    x
+    return x
 end


### PR DESCRIPTION
Additional GPU-enabled versions of ldl_striped_matrix!, trsv_striped_matrix! , cholesky_striped_matrix! (in linalg) and array_delay (in filters), all feeding into GPU-enabled version of loglikelihood in isoisolikelihood.jl